### PR TITLE
Neighborhoods dropdown

### DIFF
--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -23,7 +23,7 @@ body {
 
 .mainHeader h1 {
     font-size: 24px;
-    opacity: .8;
+    opacity: .9;
 }
 
 .mainContainer {
@@ -42,7 +42,7 @@ body {
 
 .infoPanel {
     background: white;
-    opacity: .8;
+    opacity: .9;
     padding: 10px;
     width: 300px;
 }

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -1,3 +1,8 @@
 /*
 This stylesheet is for all styles specific to the map itself (popups, zoom controls, etc.).
 */
+
+.popupAttributes .labelName {
+    color: darkolivegreen;
+    font-weight: bold;
+}

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
         <label for="neigbhorbood-select-box">Neighborhood:</label>
         <select name="neighborhood-select-box" id="neigbhorbood-select-box">
             <option value="" disabled>Select a Neighborhood</option>
+            <option value="ALL">ALL</option>
         </select>
         <h3>Filter Trees by Condition</h3>
         <form>

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -1,7 +1,7 @@
 function getMap(){
 
     var myMap;
-
+    var $neighborhoodSelectBox = $('#neigbhorbood-select-box');
     // default values
     var myCenterCoords = [45.5231, -122.6765];
     var defaultZoom = getZoomValue();
@@ -24,6 +24,7 @@ function getMap(){
     myMap.zoomControl.setPosition('bottomright');
 
     getData(myMap);
+    getNeighborhoodList();
 
     function getData(map) {
         $.ajax("https://tcasiano.carto.com/api/v2/sql?format=GeoJSON&q=SELECT * FROM pdx_street_trees WHERE neighborho ILIKE 'ALAMEDA'", {
@@ -41,6 +42,17 @@ function getMap(){
         });
     }
 
+    function getNeighborhoodList() {
+        $.getJSON('https://tcasiano.carto.com/api/v2/sql/?q=SELECT DISTINCT neighborho FROM pdx_street_trees ORDER BY neighborho ASC', function(data) {
+            $.each(data.rows, function(key, val) {
+                $neighborhoodSelectBox.append($('<option/>', {
+                    value: val.neighborho,
+                    text : val.neighborho
+                }));
+            });
+        });
+    }
+
     function pointToLayer(feature, latlng) {
 
         var geojsonMarkerOptions =  {
@@ -53,7 +65,7 @@ function getMap(){
         };
 
         var layer = L.circleMarker(latlng, geojsonMarkerOptions);
-        var popupContent = "<p><strong>Properties: </strong> " + JSON.stringify(feature.properties) + "</p>";;
+        var popupContent = "<p><strong>Properties: </strong> " + JSON.stringify(feature.properties) + "</p>";
         layer.bindPopup(popupContent);
         return layer;
     }

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -7,7 +7,7 @@ function getMap(){
     var $neighborhoodSelectBox = $('#neigbhorbood-select-box');
 
     // default values
-    var myCenterCoords = [45.5231, -122.6765];
+    var pdxCenterCoords = [45.5231, -122.6765];
     var defaultZoom = getZoomValue();
 
     var selectedNeighborhood = 'ALAMEDA';
@@ -23,7 +23,7 @@ function getMap(){
     };
 
     // create leaflet objects
-    myMap = L.map('map', {layers: [cartoDB]}).setView(myCenterCoords, defaultZoom);
+    myMap = L.map('map', {layers: [cartoDB]}).setView(pdxCenterCoords, defaultZoom);
 
     L.tileLayer.provider('CartoDB.Positron').addTo(myMap);
     L.control.layers(baseMaps).addTo(myMap);
@@ -74,6 +74,9 @@ function getMap(){
             // set event listener on neighborhood select box
             $neighborhoodSelectBox.on('change', function() {
                 var selectedNeighborhood = this.value;
+                if (myMap.getZoom() > 12) {
+                    myMap.setView(pdxCenterCoords, defaultZoom);
+                }
                 getData(myMap, selectedNeighborhood);
             });
         });

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -51,13 +51,16 @@ function getMap(){
                     disableClusteringAtZoom: 18,
                     showCoverageOnHover: true,
                     zoomToBoundsOnClick: true,
-                    spiderfyOnMaxZoom: false
+                    spiderfyOnMaxZoom: false,
+                    polygonOptions: {
+                        color: 'yellowgreen',
+                        weight: 2,
+                        opacity: 0.9 
+                    }
                 });
                 selectedMarkerClusterGroup = markers;
                 markers.addLayer(geojsonLayer);
                 map.addLayer(markers);
-
-                // TODO(Tree): zoom to newly selected neighborhood
             }
         });
     }
@@ -85,7 +88,7 @@ function getMap(){
     function pointToLayer(feature, latlng) {
         var geojsonMarkerOptions =  {
             radius: 5,
-            fillColor: "#0e8b2e",
+            fillColor: "yellowgreen",
             color: "#000",
             weight: 1,
             opacity: 1,

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -47,7 +47,12 @@ function getMap(){
                     map.removeLayer(selectedMarkerClusterGroup);
                 }
                 // add new markers
-                var markers = L.markerClusterGroup();
+                var markers = L.markerClusterGroup({
+                    disableClusteringAtZoom: 18,
+                    showCoverageOnHover: true,
+                    zoomToBoundsOnClick: true,
+                    spiderfyOnMaxZoom: false
+                });
                 selectedMarkerClusterGroup = markers;
                 markers.addLayer(geojsonLayer);
                 map.addLayer(markers);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -112,7 +112,6 @@ function getMap(){
     }
 
     function createPopupContent(props) {
-        console.log(props);
         var treeAddress = createString("Address: ", props.address);
         var treeCommonName = createString("Tree Common Name: ", props.common);
         var treeScientificName = createString("Tree Scientific Name: ", props.scientific);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -31,7 +31,7 @@ function getMap(){
 
     getData(myMap, selectedNeighborhood);
 
-    // retrieve list of distinct neighborhoods from database and set event listener on select box
+    // retrieve list of distinct neighborhoods from database and set event listeners on select box
     getNeighborhoodList();
 
     function getData(map, neighborhood) {
@@ -41,7 +41,6 @@ function getMap(){
                 var geojsonLayer = L.geoJson(response, {
                     pointToLayer: pointToLayer
                 });
-
 
                 // add new markers
                 var markers = L.markerClusterGroup({
@@ -95,7 +94,7 @@ function getMap(){
         };
 
         var layer = L.circleMarker(latlng, geojsonMarkerOptions);
-        var popupContent = "<p><strong>Properties: </strong> " + JSON.stringify(feature.properties) + "</p>";
+        var popupContent = createPopupContent(feature.properties);
         layer.bindPopup(popupContent);
         return layer;
     }
@@ -110,6 +109,20 @@ function getMap(){
         } else  {
             return 12;
         }
+    }
+
+    function createPopupContent(props) {
+        console.log(props);
+        var treeAddress = createString("Address: ", props.address);
+        var treeCommonName = createString("Tree Common Name: ", props.common);
+        var treeScientificName = createString("Tree Scientific Name: ", props.scientific);
+        var treeCondition = createString("Tree Condition: ", props.condition);
+        var popupContent = treeAddress + treeCommonName + treeScientificName + treeCondition;
+        
+        function createString(labelName, propValue) {
+            return "<div class='popupAttributes'><span class='labelName'>" + labelName + "</span> " + propValue + "</div>";
+        }
+        return popupContent;
     }
 }
 

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -10,7 +10,7 @@ function getMap(){
     var pdxCenterCoords = [45.5231, -122.6765];
     var defaultZoom = getZoomValue();
 
-    var selectedNeighborhood = 'ALAMEDA';
+    var selectedNeighborhood = '';
 
     /*tile layers*/
     var cartoDB = L.tileLayer.provider('CartoDB.Positron');
@@ -42,10 +42,7 @@ function getMap(){
                     pointToLayer: pointToLayer
                 });
 
-                //if previous marker cluster group exists, remove it
-                if (selectedMarkerClusterGroup) {
-                    map.removeLayer(selectedMarkerClusterGroup);
-                }
+
                 // add new markers
                 var markers = L.markerClusterGroup({
                     disableClusteringAtZoom: 18,
@@ -76,10 +73,12 @@ function getMap(){
 
             // set event listener on neighborhood select box
             $neighborhoodSelectBox.on('change', function() {
-                var selectedNeighborhood = this.value;
-                if (myMap.getZoom() > 12) {
-                    myMap.setView(pdxCenterCoords, defaultZoom);
+                selectedNeighborhood = this.value;
+                //if previous marker cluster group exists, remove it
+                if (selectedMarkerClusterGroup) {
+                    myMap.removeLayer(selectedMarkerClusterGroup);
                 }
+                myMap.setView(pdxCenterCoords, defaultZoom);
                 getData(myMap, selectedNeighborhood);
             });
         });


### PR DESCRIPTION
This change accomplishes the following: 
- populates the neighborhoods dropdown with an ajax call to the Carto db 
- removes any maker clusters on the map and replaces them with the new ones whenever a neighborhood is selected
- sets the default dropdown option to `All` and shows no marker clusters
- zooms back to city extent when a different neighborhood is selected (when we incorporate the neighborhood polygons, we can zoom to the bounds of the new neighborhood)
- add some maker cluster options for styling the polygon that shows the extent of any particular marker cluster
- tidies up the popups and adds a function to easily add more attributes when it comes time to properly style and format the labels (I know popup styling is beyond the scope of this pull request, but since it's just the two of us, I thought it would be okay to do a tiny change to set us up for later work. I just couldn't bare looking at them in such an ugly naked state.) 