### PR TITLE
Tree condition filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 scratch.md
+settings.json

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -6,3 +6,36 @@ This stylesheet is for all styles specific to the map itself (popups, zoom contr
     color: darkolivegreen;
     font-weight: bold;
 }
+
+/*
+Marker cluster plugin CSS overrides
+*/
+
+.marker-cluster-small,
+.marker-cluster-medium,
+.marker-cluster-large {
+	background-color: rgba(181, 226, 140, 0.6);
+	}
+.marker-cluster-small div,
+.marker-cluster-medium div,
+.marker-cluster-large div {
+    background-color: rgba(107, 142, 35, 0.6);
+    color: white;
+    }
+    
+	/* IE 6-8 fallback colors */
+.leaflet-oldie .marker-cluster-small,
+.leaflet-oldie .marker-cluster-medium,
+.leaflet-oldie .marker-cluster-large {
+	background-color: rgb(181, 226, 140);
+	}
+.leaflet-oldie .marker-cluster-small div,
+.leaflet-oldie .marker-cluster-medium div,
+.leaflet-oldie .marker-cluster-large div {
+    background-color: rgb(110, 204, 57);
+    color: white;
+	}
+
+.marker-cluster div {
+    font: 12px 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}

--- a/index.html
+++ b/index.html
@@ -45,12 +45,12 @@
             <option value="ALL">ALL</option>
         </select>
         <h3>Filter Trees by Condition</h3>
-        <form>
-            <input type="radio" name="treeCondition" value="" title="" checked> All<br>
-            <input type="radio" name="treeCondition" value="good" title="" > Good<br>
-            <input type="radio" name="treeCondition" value="fair" title="" > Fair<br>
-            <input type="radio" name="treeCondition" value="poor" title="" > Poor<br>
-            <input type="radio" name="treeCondition" value="dead" title="" > Dead<br>
+        <form name="treeConditionFilter">
+            <input type="radio" name="treeCondition" value="" title="No tree condition filter." checked> All<br>
+            <input type="radio" name="treeCondition" value="good" title="Filter trees where tree condition is good." disabled> Good<br>
+            <input type="radio" name="treeCondition" value="fair" title="Filter trees where tree condition is fair." disabled> Fair<br>
+            <input type="radio" name="treeCondition" value="poor" title="Filter trees where tree condition is poor." disabled> Poor<br>
+            <input type="radio" name="treeCondition" value="dead" title="Filter trees where tree condition is dead." disabled> Dead<br>
         </form>
         <!-- <h3>Filter Trees by Presence of Wires</h3>
         <form>

--- a/index.html
+++ b/index.html
@@ -46,14 +46,15 @@
         </select>
         <h3>Filter Trees by Condition</h3>
         <form>
-            <input type="checkbox" name="conditionFilter" value="good" title=""> Good<br>
-            <input type="checkbox" name="conditionFilter" value="fair" title=""> Fair<br>
-            <input type="checkbox" name="conditionFilter" value="poor" title=""> Poor<br>
-            <input type="checkbox" name="conditionFilter" value="dead" title=""> Dead<br>
+            <input type="radio" name="treeCondition" value="" title="" checked> All<br>
+            <input type="radio" name="treeCondition" value="good" title="" > Good<br>
+            <input type="radio" name="treeCondition" value="fair" title="" > Fair<br>
+            <input type="radio" name="treeCondition" value="poor" title="" > Poor<br>
+            <input type="radio" name="treeCondition" value="dead" title="" > Dead<br>
         </form>
         <h3>Filter Trees by Presence of Wires</h3>
         <form>
-            <input type="checkbox" name="wireFilter" value="highVoltage" title=""> High Voltage<br>
+            <input type="checkbox" name="wireFilter" value="highVoltage" title=""> High Voltage Only<br>
         </form>
         <h3>Filter Trees by Type</h3>
         <form>

--- a/index.html
+++ b/index.html
@@ -52,15 +52,16 @@
             <input type="radio" name="treeCondition" value="poor" title="" > Poor<br>
             <input type="radio" name="treeCondition" value="dead" title="" > Dead<br>
         </form>
-        <h3>Filter Trees by Presence of Wires</h3>
+        <!-- <h3>Filter Trees by Presence of Wires</h3>
         <form>
             <input type="checkbox" name="wireFilter" value="highVoltage" title=""> High Voltage Only<br>
         </form>
         <h3>Filter Trees by Type</h3>
         <form>
-            <input type="checkbox" name="typeFilter" value="deciduous" title=""> Deciduous<br>
-            <input type="checkbox" name="typeFilter" value="evergreen" title=""> Evergreen<br>
-        </form>
+            <input type="radio" name="typeFilter" value="" title="" checked> All<br>
+            <input type="radio" name="typeFilter" value="deciduous" title=""> Deciduous<br>
+            <input type="radio" name="typeFilter" value="evergreen" title=""> Evergreen<br>
+        </form> -->
     </div>
     <div class="infoPanel__bar"></div>
 </div>

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -85,13 +85,28 @@ function getMap(){
 
     function pointToLayer(feature, latlng) {
         var geojsonMarkerOptions =  {
-            radius: 5,
-            fillColor: "yellowgreen",
-            color: "#000",
+            radius: 6,
+            fillColor: getFillColor(feature.properties.condition),
+            color: '#000',
             weight: 1,
             opacity: 1,
             fillOpacity: 0.9
         };
+
+        function getFillColor(conditionProperty) {
+            switch (conditionProperty.toLowerCase()) {
+                case 'good':
+                    return '#ADFF2F';
+                case 'fair':
+                    return '#93D843';
+                case 'poor':
+                    return 'darkolivegreen';
+                case 'dead':
+                    return 'black';
+                default:
+                    return 'white';                
+            }
+        }
 
         var layer = L.circleMarker(latlng, geojsonMarkerOptions);
         var popupContent = createPopupContent(feature.properties);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -125,7 +125,7 @@ function getMap(){
         var geojsonMarkerOptions =  {
             radius: 6,
             fillColor: getFillColor(feature.properties.condition),
-            color: '#000',
+            color: '#696969',
             weight: 1,
             opacity: 1,
             fillOpacity: 0.9

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -35,7 +35,8 @@ function getMap(){
     getNeighborhoodList();
 
     function getData(map, neighborhood) {
-        $.ajax("https://tcasiano.carto.com/api/v2/sql?format=GeoJSON&q=SELECT * FROM pdx_street_trees WHERE neighborho ILIKE '" + neighborhood + "'", {
+        var ajaxCall = createAjaxCall(neighborhood);
+        $.ajax(ajaxCall, {
             dataType: 'json',
             success: function(response) {
                 var geojsonLayer = L.geoJson(response, {
@@ -137,6 +138,13 @@ function getMap(){
             return "<div class='popupAttributes'><span class='labelName'>" + labelName + "</span> " + propValue + "</div>";
         }
         return popupContent;
+    }
+
+    function createAjaxCall(neighborhood) {
+        var url = "https://tcasiano.carto.com/api/v2/sql?format=GeoJSON&q=";
+        var query = "SELECT * FROM pdx_street_trees WHERE neighborho ILIKE '" + neighborhood + "'";
+        var ajaxString = url + query;
+        return ajaxString;
     }
 }
 

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -90,6 +90,19 @@ function getMap(){
             // set event listener on neighborhood select box
             $neighborhoodSelectBox.on('change', function() {
                 selectedNeighborhood = this.value;
+                if (selectedNeighborhood === 'ALL' || selectedNeighborhood === false) {
+                    // reset and disable filters
+                    treeConditionRadioButtons[0].checked=true;
+                    for (var i = 0; i< treeConditionRadioButtons.length;  i++){
+                        treeConditionRadioButtons[i].disabled = true;
+                    }
+                } else {
+                    //enable radio buttons
+                    for (var j = 0; j< treeConditionRadioButtons.length;  j++){
+                        treeConditionRadioButtons[j].disabled = false;
+                    }
+                }
+
                 //if previous marker cluster group exists, remove it
                 if (selectedMarkerClusterGroup) {
                     myMap.removeLayer(selectedMarkerClusterGroup);


### PR DESCRIPTION
@sethfrazier  
This pull request adds the following changes:

- Tree points are color coded based on tree condition.
- Simple filtering for tree condition has been added.
- Filters that have yet to be enabled are hidden (temporarily commented out) for the time being.
- Filters are disabled on initial load.
- Filters are enabled and disabled based on state of selectedNeighborhood.
- Filters are reset to 'All' when selectedNeighborhood is set to 'All.'
- Marker clusters are all one color now. The colors for the clusters changed based on marker cluster size, but this coloring seems confusing, especially since we are using similar coloring to encode the point features. We can refine the colors in a future iteration. 
- The border color on the point features was softened. (I also tried a white border, but it made some of the points harder to see.)

It's a little hard to tell the 'good' trees from the 'fair' trees in this screenshot, so we may need to do some more refining here later.
<img width="1437" alt="tree-point-features-color-coded" src="https://user-images.githubusercontent.com/7842151/38472740-605bd240-3b39-11e8-8e1d-1cc1e26d1798.png">

<img width="1434" alt="all-clusters-now-same-color" src="https://user-images.githubusercontent.com/7842151/38472741-68544a9a-3b39-11e8-9e00-924fb7e6ca69.png">

This is what the default styling is for the radio buttons in their disabled state. We probably should consider making this change more discernible when do our final round of styling polish. 
<img width="337" alt="filters-disabled-unless-neighborhood-selected" src="https://user-images.githubusercontent.com/7842151/38472744-6f34a7f6-3b39-11e8-8fd7-72d006b052f8.png">
