### PR TITLE
Fix bug where apostrophe in "SULLIVAN'S GULCH" breaks the SQL query

### DIFF
--- a/js/geojson.js
+++ b/js/geojson.js
@@ -294,6 +294,11 @@ function getMap(){
     }
 
     function createAjaxCall(neighborhood) {
+        if (neighborhood === "SULLIVAN'S GULCH") {
+            // the correct way to escape a SQL apostrophe or single quote 
+            // is with two single quotes
+            neighborhood = "SULLIVAN''S GULCH";
+        }
         var url = "https://tcasiano.carto.com/api/v2/sql?format=GeoJSON&q=";
         var query = "SELECT * FROM pdx_street_trees WHERE neighborho ILIKE '" + neighborhood + "'";
         


### PR DESCRIPTION
The SQL statement needs the apostrophe in Sullivan's Gulch to be escaped. Without it, the query is breaking and we get no trees. Two single quotes in a row are the preferred way to perform this particular character escape in SQL. Now we'll get dots on the map for this neighborhood. 

I didn't see any others in our list that use an apostrophe. 