### PR TITLE
Handle zero filter results

### DIFF
--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -237,3 +237,19 @@ input[type=checkbox]:hover {
 .deadColor {
     background: #34220B;
 }
+
+.filter-feedback {
+    background:  #474849;
+    box-shadow: 0 0 10px 0 #474849;
+    color: white;
+    display: none;
+    font-size: 20px;
+    opacity: .9;
+    padding: 10px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -50px;
+    margin-left: -50px;
+    z-index: 10000;
+}

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 <div id="main-header-menu" class="mainHeader__dropdownMenu">
     <ul>
         <li id="about-menu-item">
-            <a href="#overlay">About This Map</a>
+            <a href="#">About This Map</a>
         </li>
         <li>
             <a href="https://github.com/uw-project-group/portland-street-trees">Project Source Code</a>
@@ -60,7 +60,9 @@
     <p>Select a neighorhood to view individual trees in that neigbhorhood as well as aggregate neighborhood statistics.</p>
     <p>Filter trees by their health condition, by tree type, and by whether or not they are near high voltage wires.</p>
     
-</div>    
+</div>  
+
+<div id="filter-feedback" class="filter-feedback">0 results for selected filter(s)</div>
 
 <div class="infoPanel__container">
     <div class="infoPanel">

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -74,7 +74,7 @@ function getMap(){
     L.tileLayer.provider('CartoDB.Positron').addTo(myMap);
     L.control.layers(baseMaps,overylayMaps).addTo(myMap);
     myMap.zoomControl.setPosition('bottomright');
-
+    myMap.options.minZoom = 10;
     getData(myMap, selectedNeighborhood);
     
     getNeighborhoodPoly(myMap);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -5,6 +5,7 @@ function getMap(){
 
     /* jquery variables */
     var $neighborhoodSelectBox = $('#neigbhorbood-select-box');
+    var $filterFeedback = $('#filter-feedback');
 
     /* default map values */
     var pdxCenterCoords = [45.5410, -122.6769];
@@ -122,14 +123,13 @@ function getMap(){
             success: function(response) {
                 if (!response.features.length) {
                     if (!neighborhood || neighborhood === 'ALL') {
-                        // we return early for this condition 
-                        // because we only want to trigger the display
+                        // we return early because we only want to trigger the display
                         // of the feedback if a single neighborhood is selected
-                        console.log("No single neighborhood selected.");
                         return;
                     }
-                    console.log("There are no results in this query.");
-                    $('#filter-feedback').fadeIn('slow');
+                    $filterFeedback.hide();
+                    $filterFeedback.text('');
+                    $filterFeedback.fadeIn('slow').text('0 results for selected filter(s)');
                 }
 
                 var geojsonLayer = L.geoJson(response, {
@@ -202,7 +202,10 @@ function getMap(){
                                 $neighborhoodSelectBox.val(neighborhoodName).change();
                             } else if (feature.properties.TreeTotal === 0) {
                                 // TODO(Tree): handle null values gracefully and give feedback to user
-                                console.log('Neighborhood with 0 Street Trees: ', neighborhoodName);
+                                $filterFeedback.hide();
+                                $filterFeedback.text('');
+                                $filterFeedback.fadeIn('slow').text("No street trees have been inventoried for " + neighborhoodName + '.');
+                                console.log("No street trees have been inventoried for " + neighborhoodName + '.');
                             }
                         }
                     });

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -10,7 +10,6 @@ function getMap(){
     /* default map values */
     var pdxCenterCoords = [45.5410, -122.6769];
     var defaultZoom = getZoomValue();
-    var maxZoom = 13;
     
     /*limits to panning*/
     var southWest = L.latLng(45.411, -122.922),

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -102,6 +102,18 @@ function getMap(){
         $.ajax(ajaxCall, {
             dataType: 'json',
             success: function(response) {
+                if (!response.features.length) {
+                    if (!neighborhood || neighborhood === 'ALL') {
+                        // we return early for this condition 
+                        // because we only want to trigger the display
+                        // of the feedback if a single neighborhood is selected
+                        console.log("No single neighborhood selected.");
+                        return;
+                    }
+                    console.log("There are no results in this query.");
+                    $('#filter-feedback').fadeIn('slow');
+                }
+
                 var geojsonLayer = L.geoJson(response, {
                     pointToLayer: pointToLayer
                 });

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,12 @@
 function initialize(){
     var $aboutMenuItem = $('#about-menu-item');
+    var $filters = $('.filters');
+    var $filterFeedback = $('#filter-feedback');
     var $infoPanel = $('.infoPanel');
     var $infoPanelToggle = $('.infoPanel__bar');
     var $infoButton = $('#main-header-info-button');
     var $mainHeaderMenu = $('#main-header-menu');
+    var $map = $('#map');
     var $neighborhoodSelectBox = $('#neigbhorbood-select-box');
     var $overlayCloseButton = $('#overlay-close-button');
     var $overlay = $('#overlay');
@@ -20,14 +23,23 @@ function initialize(){
         $mainHeaderMenu.slideToggle();
     });
 
+    $filters.click(function() {
+        $filterFeedback.fadeOut('slow');
+    });
+
+    $map.click(function() {
+        $filterFeedback.fadeOut('slow');
+    });
+
     $neighborhoodSelectBox.click(function() {
         $overlay.fadeOut('slow');
-        overlayIsHidden = true;
+        $filterFeedback.fadeOut('slow');
+        // overlayIsHidden = true;
     });
 
     $overlayCloseButton.click(function () {
         $overlay.fadeOut('slow');
-        overlayIsHidden = true; 
+        // overlayIsHidden = true; 
     });
 }
 


### PR DESCRIPTION
There is now a message for that fades in and out for the cases where there are no inventoried street trees or no filter results for any given query. I'm not sold on the styling I have chosen, but I know we're not done with the styling and font decisions anyway and can adjust this later. 