### PR TITLE
Format and style popups

### DIFF
--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -55,7 +55,7 @@ select {
 }
 
 .mainHeader button:hover {
-    color: yellowgreen;
+    color: #66bd63;
     cursor: pointer;
 }
 
@@ -91,7 +91,7 @@ select {
 .mainHeader__dropdownMenu a:hover,
 .mainHeader__dropdownMenu a:focus {
     color: white;
-    background: yellowgreen;
+    background: #66bd63;
     outline: none;
 }
 
@@ -131,7 +131,7 @@ select {
 }
 
 .overlay__closeButton:hover {
-    color: yellowgreen;
+    color: #66bd63;
 }
 
 .infoPanel__container {
@@ -181,12 +181,12 @@ select {
 }
 
 .infoPanel select:hover {
-    border: 1px solid yellowgreen;
+    border: 1px solid #66bd63;
     outline: none;
 }
 
 .infoPanel select:focus {
-    border: 1px solid greenyellow;
+    border: 1px solid #66bd63;
     outline: none;
 }
 
@@ -195,7 +195,7 @@ select {
 }
 
 .filters label:hover {
-    color: yellowgreen;
+    color: #66bd63;
     cursor: pointer;
 }
 

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -11,6 +11,13 @@ This stylesheet is for all styles specific to the map itself (popups, zoom contr
     font: 12px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
+.leaflet-tooltip {
+    background-color: yellowgreen;
+    border: green;
+    color: white;
+    font: 20px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
 /*
 Marker cluster plugin CSS overrides
 */

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -12,10 +12,11 @@ This stylesheet is for all styles specific to the map itself (popups, zoom contr
 }
 
 .leaflet-tooltip {
-    background-color: yellowgreen;
-    border: green;
-    color: white;
+    background-color: white;
+    border: lightgrey;
+    color: black;
     font: 20px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    padding: 10px;
 }
 
 /*
@@ -25,12 +26,12 @@ Marker cluster plugin CSS overrides
 .marker-cluster-small,
 .marker-cluster-medium,
 .marker-cluster-large {
-	background-color: rgba(181, 226, 140, 0.6);
+	background-color: #66bd63;
 	}
 .marker-cluster-small div,
 .marker-cluster-medium div,
 .marker-cluster-large div {
-    background-color: rgba(107, 142, 35, 0.6);
+    background-color: rgba(71, 72, 73, 0.6);
     color: white;
     }
     
@@ -38,7 +39,7 @@ Marker cluster plugin CSS overrides
 .leaflet-oldie .marker-cluster-small,
 .leaflet-oldie .marker-cluster-medium,
 .leaflet-oldie .marker-cluster-large {
-	background-color: rgb(181, 226, 140);
+	background-color: rgb(102,189,99);
 	}
 .leaflet-oldie .marker-cluster-small div,
 .leaflet-oldie .marker-cluster-medium div,

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -5,9 +5,32 @@ This stylesheet is for all styles specific to the map itself (popups, zoom contr
 .popupAttributes .labelName {
     color: black;
     font-weight: bold;
+    margin-right: 6px;
 }
 
 .popupAttributes {
+    font: 14px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+.leaflet-popup,
+.leaflet-popup-content {
+    width: 275px;
+}
+
+.leaflet-popup h1 {
+    color: #66bd63;
+    font: 18px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: .8;
+}
+
+.leaflet-popup hr {
+    width: 80%;
+}
+
+/*
+Leaflet overrides
+*/
+.leaflet-control {
     font: 12px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
@@ -49,9 +72,5 @@ Marker cluster plugin CSS overrides
 	}
 
 .marker-cluster div {
-    font: 12px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-}
-
-.leaflet-control {
     font: 12px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -162,7 +162,7 @@ function getMap(){
 
                 function onEachFeature(feature, layer) {
                     var neighborhoodName = feature.properties.NAME;
-                    layer.bindTooltip(neighborhoodName);
+                    layer.bindTooltip(neighborhoodName, {sticky: true, direction: 'bottom'});
                     // populate the pseudo-global objects declared at the top of this file
                     // on order to hold values so that the dropdown can access them
                     allBounds[neighborhoodName] = layer.getBounds();

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -153,7 +153,8 @@ function getMap(){
                     fillOpacity: 0,
                     color: 'green',
                     opacity:0.4,
-                }
+                };
+
                 L.geoJson(response,{
                     style: neighborOptions,
                     onEachFeature: onEachFeature
@@ -161,7 +162,7 @@ function getMap(){
 
                 function onEachFeature(feature, layer) {
                     var neighborhoodName = feature.properties.NAME;
-
+                    layer.bindTooltip(neighborhoodName);
                     // populate the pseudo-global objects declared at the top of this file
                     // on order to hold values so that the dropdown can access them
                     allBounds[neighborhoodName] = layer.getBounds();
@@ -192,6 +193,19 @@ function getMap(){
                                 // TODO(Tree): handle null values gracefully and give feedback to user
                                 console.log('Neighborhood with 0 Street Trees: ', neighborhoodName);
                             }
+                            // tooltip should remain closed on click
+                            layer.closeTooltip();
+                        },
+                        mouseover: function(e) {
+                            // tooltip should remain closed if the neighborhood has already been selected
+                            if (neighborhoodName == selectedNeighborhood){
+                                layer.closeTooltip();
+                            } else {
+                                layer.openTooltip();
+                            }
+                        },
+                        mouseout: function(e) {
+                            layer.closeTooltip();
                         }
                     });
                 } 

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -142,7 +142,7 @@ function getMap(){
                     zoomToBoundsOnClick: true,
                     spiderfyOnMaxZoom: false,
                     polygonOptions: {
-                        color: 'yellowgreen',
+                        color: '#66bd63',
                         weight: 2,
                         opacity: 0.9 
                     }
@@ -165,7 +165,7 @@ function getMap(){
                     color: '#003300',
                     opacity:0.8,
                 };
-                
+
                 L.geoJson(response,{
                     style: neighborOptions,
                     onEachFeature: onEachFeature

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -325,18 +325,46 @@ function getMap(){
     }
 
     function createPopupContent(props) {
-        var treeAddress = createString("Address: ", props.address);
-        var treeCommonName = createString("Tree Common Name: ", props.common);
-        var treeScientificName = createString("Tree Scientific Name: ", props.scientific);
-        var treeCondition = createString("Tree Condition: ", props.condition);
-        var wiresPresent = createString("Wires Present: ", props.wires);
-        var functionalType = createString("Functional Type: ", props.functional);
-        var popupContent = treeAddress + treeCommonName + treeScientificName + treeCondition + wiresPresent + functionalType;
-        
-        function createString(labelName, propValue) {
-            return "<div class='popupAttributes'><span class='labelName'>" + labelName + "</span> " + propValue + "</div>";
-        }
+        //reformat text for No HV wire prop to more user-friendly text
+        var wiresProps = props.wires === 'No HV' ? 'No high voltage' : props.wires;
+
+        var popupTitle = "<h1>" + props.common.toUpperCase()  + "</h1>";
+        var treeScientificName = createPopupAttributeText("Scientific Name: ", props.scientific);
+        var treeAddress = createPopupAttributeText("Address: ", props.address);
+        var treeCondition = createPopupAttributeText("Tree Condition: ", props.condition);
+        var wiresPresent = createPopupAttributeText("Wires Present: ", wiresProps);
+        var functionalType = createPopupAttributeText("Functional Type: ", convertTreeTypeToText(props.functional));
+        var popupContent = popupTitle + "<hr>"  + treeAddress  + treeScientificName + treeCondition + wiresPresent + functionalType;
+    
         return popupContent;
+    }
+
+    function convertTreeTypeToText(treeType) {
+        var fullText = '';
+        switch(treeType.toUpperCase()) {
+            case 'BD':
+            fullText = 'Broadleaf Deciduous';
+                break;
+            case 'BE':
+            fullText = 'Broadleaf Evergreen';
+                break;
+            case 'CD':
+            fullText = 'Coniferous Deciduous';
+                break;
+            case 'CE':
+            fullText = 'Coniferous Evergreen';
+                break;    
+            case 'PALM':
+            fullText = 'Palm';
+                break;      
+            default:
+            fullText = 'Unknown';
+        }
+        return fullText;
+    }
+
+    function createPopupAttributeText(labelName, propValue) {
+        return "<div class='popupAttributes'><span class='labelName'>" + labelName + "</span> " + propValue + "</div>";
     }
 
     function createAjaxCall(neighborhood) {


### PR DESCRIPTION
I adjusted the rest of our colors to match those of the new colors for the point features and chart. I  also added some functions to make constructing the popup content easier. 

We now also have popups (technically Leaflet tooltips) for the neighborhoods themselves as well as the point features. I've made the neighborhood popups/tooltips stick to the mouse and only show on neighborhoods if they are not the currently selected neighborhood to minimize any noise once the marker clusters appear.

I stuck with a simple black text on white for all the popups/tooltips since that seemed much easier to read. 

![image](https://user-images.githubusercontent.com/7842151/39256726-77f730b0-4864-11e8-9e61-689bedac4bc1.png)

![image](https://user-images.githubusercontent.com/7842151/39256948-16beb0e2-4865-11e8-9c51-44358cd46df4.png)

