### PR TITLE
Redesign info panel

### DIFF
--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -45,7 +45,8 @@ select {
 
 .mainHeader h1 {
     font-size: 16px;
-    padding: 0 15px;
+    margin-left: 20px;
+    margin-top: 15px;
 }
 
 .mainHeader button {
@@ -101,14 +102,13 @@ select {
     border-radius: 5px;
     box-shadow: 0 0 10px 0 #474849;
     color: #474849;
-    display: none;
     opacity: .95;
     padding: 10px;
     position: absolute;
-    top: 40%;
-    left: 40%;
-    margin-top: -50px;
-    margin-left: -50px;
+    top: 20%;
+    margin: 0 auto;
+    right: 10%;
+    left: 10%;
     max-width: 500px;
     z-index: 10000;
 }
@@ -118,7 +118,7 @@ select {
 }
 
 .overlay__headingContainer h2 {
-    line-height: .25;
+    line-height: 1;
 }
 
 .overlay__closeButton {
@@ -295,5 +295,10 @@ input[type=checkbox]:disabled {
 
     .mainHeader__dropdownMenu a {
         padding: 10px;
+    }
+
+    .overlay {
+        right: 10%;
+        left: 30%;
     }
 }

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -282,7 +282,7 @@ input[type=checkbox]:disabled {
     }
 
     .infoPanel h2 {
-        font-size: 24px;
+        font-size: 20px;
     }
     
     .infoPanel h3 {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -144,7 +144,6 @@ select {
 
 .infoPanel {
     background: white;
-    opacity: .9;
     overflow: auto;
     padding: 15px 15px 100px 15px;
     width: 300px;
@@ -158,11 +157,11 @@ select {
     cursor: pointer;
     font-size: 22px;
     height: 25px;
-    margin-left: -15px;
+    margin-left: -16px;
     overflow: visible;
-    padding: 5px 2px 5px 12px;
-    text-align: center;
-    width: 35px;
+    padding: 5px 8px 5px 5px;
+    text-align: right;
+    width: 25px;
     z-index: 100;
 }
 

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -105,7 +105,7 @@ select {
     opacity: .95;
     padding: 10px;
     position: absolute;
-    top: 20%;
+    top: 30%;
     margin: 0 auto;
     right: 10%;
     left: 10%;

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -97,6 +97,7 @@ select {
 
 .overlay {
     background: white;
+    border-radius: 5px;
     box-shadow: 0 0 10px 0 #474849;
     color: #474849;
     display: none;
@@ -253,8 +254,8 @@ input[type=checkbox]:disabled {
 
 .filter-feedback {
     background:  #474849;
-    box-shadow: 0 0 10px 0 #474849;
     border-radius: 5px;
+    box-shadow: 0 0 10px 0 #474849;
     color: white;
     display: none;
     font-size: 20px;

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -172,11 +172,14 @@ select {
 }
 
 .infoPanel h2 {
-    font-size: 20px;
+    font-size: 18px;
+    line-height: 1;
+    text-align: center;
+    margin-top: 5px;
 }
 
 .infoPanel h3 {
-    font-size: 18px;
+    font-size: 16px;
     margin-bottom: 5px;
     margin-top: 10px;
 }
@@ -276,6 +279,14 @@ input[type=checkbox]:disabled {
 @media only screen and (min-width: 768px) {
     .infoPanel {
         width: 300px;
+    }
+
+    .infoPanel h2 {
+        font-size: 24px;
+    }
+    
+    .infoPanel h3 {
+        font-size: 18px;
     }
 
     .mainHeader h1 {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -101,10 +101,10 @@ select {
     box-shadow: 0 0 10px 0 #474849;
     color: #474849;
     display: none;
-    opacity: .9;
+    opacity: .95;
     padding: 10px;
     position: absolute;
-    top: 30%;
+    top: 40%;
     left: 40%;
     margin-top: -50px;
     margin-left: -50px;

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -150,19 +150,24 @@ select {
     width: 300px;
 }
 
-.infoPanel__bar {
-    background: #474849;
-    box-shadow: 0 0 5px 0 #555;
-    color: white;
+.infoPanel__toggle {
+    background: white;
+    border-radius: 0px 0px 5px 0px;
+    box-shadow: 8px 8px 5px -4px rgba(0,0,0,0.75);        
+    color: #474849;
     cursor: pointer;
-    opacity: .5;
-    padding-top: 10px;
+    font-size: 22px;
+    height: 25px;
+    margin-left: -15px;
+    overflow: visible;
+    padding: 5px 2px 5px 12px;
     text-align: center;
-    width: 15px;
+    width: 35px;
+    z-index: 100;
 }
 
-.infoPanel__bar:hover {
-    opacity: .8;
+.infoPanel__toggle:hover {
+    color:  #66bd63;;
 }
 
 .infoPanel h2 {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -201,12 +201,21 @@ select {
 
 .filters label:hover {
     color: #66bd63;
-    cursor: pointer;
+}
+
+input[type=radio],
+input[type=checkbox] {
+    margin-right: 2px;
 }
 
 input[type=radio]:hover,
 input[type=checkbox]:hover {
     cursor: pointer;
+}
+
+input[type=radio]:disabled,
+input[type=checkbox]:disabled {
+    cursor: not-allowed;
 }
 
 .legend-container {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -179,14 +179,14 @@ select {
 }
 
 .infoPanel h3 {
-    font-size: 16px;
+    font-size: 14px;
     margin-bottom: 5px;
     margin-top: 10px;
 }
 
 .infoPanel select {
     border: 1px solid #474849;
-    width: 100%;
+    font-size: 16px;
 }
 
 .infoPanel select:hover {
@@ -286,7 +286,7 @@ input[type=checkbox]:disabled {
     }
     
     .infoPanel h3 {
-        font-size: 18px;
+        font-size: 16px;
     }
 
     .mainHeader h1 {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -60,7 +60,7 @@ select {
 }
 
 .mainHeader button:focus {
-    color: greenyellow;
+    color: #cc9c33;
 }
 
 .mainHeader__dropdownMenu {

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -39,11 +39,12 @@ select {
     justify-content: space-between;
     opacity: .8;
     overflow: hidden;
+    padding-right: 10px;
     text-align: center;
 }
 
 .mainHeader h1 {
-    font-size: 24px;
+    font-size: 16px;
     padding: 0 15px;
 }
 
@@ -84,7 +85,7 @@ select {
     display: inline-block;
     color: whitesmoke;
     text-decoration: none;
-    padding: 10px;
+    padding: 5px;
     width: 100%;
 }
 
@@ -274,6 +275,14 @@ input[type=checkbox]:disabled {
 
 @media only screen and (min-width: 768px) {
     .infoPanel {
-        width: 320px;
+        width: 300px;
+    }
+
+    .mainHeader h1 {
+        font-size: 24px;
+    }
+
+    .mainHeader__dropdownMenu a {
+        padding: 10px;
     }
 }

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -71,7 +71,7 @@ select {
     top: 60px;
     right: 0;
     width: 225px;
-    z-index: 10000;
+    z-index: 4000;
 }
 
 .mainHeader__dropdownMenu ul {
@@ -140,14 +140,14 @@ select {
     height: 100vh;
     position: fixed;
     top: 60px;
-    z-index: 1000;
+    z-index: 3000;
 }
 
 .infoPanel {
     background: white;
     overflow: auto;
     padding: 15px 15px 100px 15px;
-    width: 300px;
+    width: 260px;
 }
 
 .infoPanel__toggle {
@@ -266,5 +266,14 @@ input[type=checkbox]:disabled {
     left: 50%;
     margin-top: -50px;
     margin-left: -50px;
-    z-index: 10000;
+    z-index: 2000;
+}
+
+
+/* MEDIA QUERIES */
+
+@media only screen and (min-width: 768px) {
+    .infoPanel {
+        width: 320px;
+    }
 }

--- a/css/main-styles.css
+++ b/css/main-styles.css
@@ -254,6 +254,7 @@ input[type=checkbox]:disabled {
 .filter-feedback {
     background:  #474849;
     box-shadow: 0 0 10px 0 #474849;
+    border-radius: 5px;
     color: white;
     display: none;
     font-size: 20px;

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -38,8 +38,9 @@ Leaflet overrides
     background-color: white;
     border: lightgrey;
     color: black;
-    font: 20px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    padding: 10px;
+    font: 14px 'Signika', 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    padding: 8px;
+    margin-top: 15px;
 }
 
 /*

--- a/css/map-styles.css
+++ b/css/map-styles.css
@@ -43,6 +43,17 @@ Leaflet overrides
     margin-top: 15px;
 }
 
+.leaflet-control-layers-base label:hover,
+.leaflet-control-layers-overlays label:hover {
+    color: #66bd63;
+    cursor: pointer;
+}
+
+.leaflet-control-zoom a:hover {
+    color: #66bd63;
+    cursor: pointer;
+}
+
 /*
 Marker cluster plugin CSS overrides
 */

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
 
 <div class="infoPanel__container">
     <div class="infoPanel">
-        <h2>Neighborhood Tree Health</h2>
+        <h2>Tree Population Health<br><span id="displayed-neighborhood">All Neighborhoods</span></h2>
         <div class = "chart-container"></div>
         <div class = "legend-container">
             <div class = "legend-container__item">  

--- a/index.html
+++ b/index.html
@@ -110,7 +110,9 @@
             <label><input type="radio" name="functionalTypeFilter" value="palm" title="Filter palm tree type." disabled> Palm<br></label>
         </form>
     </div>
-    <div class="infoPanel__bar"></div>
+    <div id="panel-collapse" class="infoPanel__toggle">
+        <i class="fas fa-caret-left fa-1x"></i>
+    </div>
 </div>
 
 <div class="mainContainer">

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <option value="ALL">ALL</option>
         </select>
         <h3>Filter Trees by Condition</h3>
-            <form class="filters" name="treeConditionFilter">
+        <form class="filters" name="treeConditionFilter">
             <label><input type="radio" name="treeCondition" value="" title="No tree condition filter." checked> All<br></label>
             <label><input type="radio" name="treeCondition" value="good" title="Filter trees where tree condition is good." disabled> Good<br></label>
             <label><input type="radio" name="treeCondition" value="fair" title="Filter trees where tree condition is fair." disabled> Fair<br></label>

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -50,6 +50,7 @@ function getMap(){
     var cartoDB = L.tileLayer.provider('CartoDB.Positron');
     var EsriImgagery = L.tileLayer.provider('Esri.WorldImagery');
     var stamenTonerLite = L.tileLayer.provider('Stamen.TonerLabels');
+
     var baseMaps = {
         '<span class="tileLayer__text">Map</span>': cartoDB,
         '<span class="tileLayer__text">Satellite Imagery</span>': EsriImgagery,
@@ -120,13 +121,10 @@ function getMap(){
             success: function(response) {
                 if (!response.features.length) {
                     if (!neighborhood || neighborhood === 'ALL') {
-                        // we return early because we only want to trigger the display
-                        // of the feedback if a single neighborhood is selected
                         return;
                     }
-                    $filterFeedback.hide();
-                    $filterFeedback.text('');
-                    $filterFeedback.fadeIn('slow').text('0 results for selected filter(s)');
+                    // only trigger feedback if a single neighborhood is selected
+                    displayFilterFeedback('0 results for selected filter(s)');
                 }
 
                 var geojsonLayer = L.geoJson(response, {
@@ -199,11 +197,8 @@ function getMap(){
                                 // so that it always is in sync with the selected neighborhood
                                 $neighborhoodSelectBox.val(neighborhoodName).change();
                             } else if (feature.properties.TreeTotal === 0) {
-                                // TODO(Tree): handle null values gracefully and give feedback to user
-                                $filterFeedback.hide();
-                                $filterFeedback.text('');
-                                $filterFeedback.fadeIn('slow').text("No street trees have been inventoried for " + neighborhoodName + '.');
-                                console.log("No street trees have been inventoried for " + neighborhoodName + '.');
+                                var feedbackMessage = 'No street trees have been inventoried for ' + neighborhoodName + '.';
+                                displayFilterFeedback(feedbackMessage);                                
                             }
                             // tooltip should remain closed on click
                             layer.closeTooltip();
@@ -395,6 +390,11 @@ function getMap(){
         return ajaxString;
     }
 
+    function displayFilterFeedback(feedbackText) {
+        $filterFeedback.hide();
+        $filterFeedback.text('');
+        $filterFeedback.fadeIn('slow').text(feedbackText);
+    }
     function getFillColor(conditionProperty) {
         switch (conditionProperty.toLowerCase()) {
             case 'good':

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -70,9 +70,10 @@ function getMap(){
     });
 
     L.tileLayer.provider('CartoDB.Positron').addTo(myMap);
-    L.control.layers(baseMaps,overylayMaps).addTo(myMap);
+    L.control.layers(baseMaps, overylayMaps).addTo(myMap);
     myMap.zoomControl.setPosition('bottomright');
     myMap.options.minZoom = 10;
+
     getData(myMap, selectedNeighborhood);
     
     getNeighborhoodPoly(myMap);
@@ -113,6 +114,20 @@ function getMap(){
             }
         });
     }
+
+    $('.leaflet-control-layers-overlays').hide();
+    $('.leaflet-control-layers-separator').hide();
+
+    myMap.on('baselayerchange', function(e) {
+        if (e.layer.options.variant === 'World_Imagery') {
+            console.log(e.layer.options.variant);
+            $('.leaflet-control-layers-overlays').show();
+            $('.leaflet-control-layers-separator').show();
+        } else {
+            $('.leaflet-control-layers-overlays').hide();
+            $('.leaflet-control-layers-separator').hide().prop('checked', false);
+        }
+      });
 
     function getData(map, neighborhood) {
         var ajaxCall = createAjaxCall(neighborhood);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -49,15 +49,10 @@ function getMap(){
     /* tile layers */
     var cartoDB = L.tileLayer.provider('CartoDB.Positron');
     var EsriImgagery = L.tileLayer.provider('Esri.WorldImagery');
-    var stamenTonerLite = L.tileLayer.provider('Stamen.TonerLabels');
 
     var baseMaps = {
         '<span class="tileLayer__text">Map</span>': cartoDB,
         '<span class="tileLayer__text">Satellite Imagery</span>': EsriImgagery,
-    };
-    
-    var overylayMaps={
-        '<span class ="overLay__text">Labels</span>':stamenTonerLite
     };
     
     /* create Leaflet map object */
@@ -70,7 +65,7 @@ function getMap(){
     });
 
     L.tileLayer.provider('CartoDB.Positron').addTo(myMap);
-    L.control.layers(baseMaps, overylayMaps).addTo(myMap);
+    L.control.layers(baseMaps).addTo(myMap);
     myMap.zoomControl.setPosition('bottomright');
     myMap.options.minZoom = 10;
 
@@ -114,20 +109,6 @@ function getMap(){
             }
         });
     }
-
-    $('.leaflet-control-layers-overlays').hide();
-    $('.leaflet-control-layers-separator').hide();
-
-    myMap.on('baselayerchange', function(e) {
-        if (e.layer.options.variant === 'World_Imagery') {
-            console.log(e.layer.options.variant);
-            $('.leaflet-control-layers-overlays').show();
-            $('.leaflet-control-layers-separator').show();
-        } else {
-            $('.leaflet-control-layers-overlays').hide();
-            $('.leaflet-control-layers-separator').hide().prop('checked', false);
-        }
-      });
 
     function getData(map, neighborhood) {
         var ajaxCall = createAjaxCall(neighborhood);

--- a/js/geojson.js
+++ b/js/geojson.js
@@ -6,6 +6,7 @@ function getMap(){
     /* jquery variables */
     var $neighborhoodSelectBox = $('#neigbhorbood-select-box');
     var $filterFeedback = $('#filter-feedback');
+    var $neighborhoodDisplayText = $('#displayed-neighborhood');
 
     /* default map values */
     var pdxCenterCoords = [45.5410, -122.6769];
@@ -52,17 +53,14 @@ function getMap(){
     var baseMaps = {
         '<span class="tileLayer__text">Map</span>': cartoDB,
         '<span class="tileLayer__text">Satellite Imagery</span>': EsriImgagery,
-        //'<span class="tileLayer__text">Stamen Toner Lite</span>': stamenTonerLite
     };
     
     var overylayMaps={
         '<span class ="overLay__text">Labels</span>':stamenTonerLite
-    }
+    };
     
-
     /* create Leaflet map object */
     myMap = L.map('map', {layers: [cartoDB]}).setView(pdxCenterCoords, defaultZoom);
-    
     
     //set bounds and animate the edge of panning area
     myMap.setMaxBounds(bounds);
@@ -252,6 +250,9 @@ function getMap(){
                         functionalTypeRadioButtons[i].disabled = true;
                     }
                     presenceOfWiresCheckBox.disabled=true;
+
+                    // set display text of selected neighborhood in info panel heading
+                    $neighborhoodDisplayText.text('All Neighborhoods');
                 } else {
                     //enable radio buttons
                     for (var i = 0; i < treeConditionRadioButtons.length;  i++){
@@ -262,6 +263,9 @@ function getMap(){
                     }
                     // enable checkbox
                     presenceOfWiresCheckBox.disabled = false;
+
+                    // set display text of selected neighborhood in info panel heading
+                    $neighborhoodDisplayText.text(selectedNeighborhood);
                 }
 
                 //if previous marker cluster group exists, remove it

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ function initialize(){
     var $filters = $('.filters');
     var $filterFeedback = $('#filter-feedback');
     var $infoPanel = $('.infoPanel');
-    var $infoPanelToggle = $('.infoPanel__bar');
+    var $infoPanelToggle = $('.infoPanel__toggle');
     var $infoButton = $('#main-header-info-button');
     var $mainHeaderMenu = $('#main-header-menu');
     var $map = $('#map');
@@ -17,6 +17,12 @@ function initialize(){
 
     $infoPanelToggle.click(function () {
         $infoPanel.toggle();
+        if ($infoPanel.is(":visible")) {
+            $infoPanelToggle.html('<i class="fas fa-caret-left fa-1x"></i>');
+        } else {
+            $infoPanelToggle.html('<i class="fas fa-caret-right fa-1x"></i>');
+        }
+
     });
 
     $infoButton.click(function () {
@@ -34,12 +40,10 @@ function initialize(){
     $neighborhoodSelectBox.click(function() {
         $overlay.fadeOut('slow');
         $filterFeedback.fadeOut('slow');
-        // overlayIsHidden = true;
     });
 
     $overlayCloseButton.click(function () {
         $overlay.fadeOut('slow');
-        // overlayIsHidden = true; 
     });
 }
 


### PR DESCRIPTION
Added a new toggle that's a tab instead of a translucent bar.
Removed opacity on infoPanel because it didn't play so well with the new toggle or the satellite base map.
Added some refinements to cursor and hover styles.
Added some media queries and z-indexes for improved responsiveness and to accommodate stacking of menus and overlays on small screens. 

I made the info panel's top heading reflect the selected neighborhood. 
I debated making the overlay visible on initial load, but didn't want to touch it without coming to a consensus. In any case, we'll need to do a little work with the overlay formatting and positioning so it works better on small screens, but that won't hold up the screen cast or any other work. It's not buggy, just not quite right. (I could lose a whole day dealing with that, I think!)

![image](https://user-images.githubusercontent.com/7842151/39315713-36a2f162-492c-11e8-94ab-468b20a16322.png)
