### PR TITLE
Set max zoom to 18

### DIFF
--- a/js/geojson.js
+++ b/js/geojson.js
@@ -68,6 +68,7 @@ function getMap(){
     L.control.layers(baseMaps).addTo(myMap);
     myMap.zoomControl.setPosition('bottomright');
     myMap.options.minZoom = 10;
+    myMap.options.maxZoom = 18;
 
     getData(myMap, selectedNeighborhood);
     


### PR DESCRIPTION
This is a quick fix for the issue where attempts to zoom in to a certain level with the satellite imagery base map switches the user to a view of the Positron base map. By setting the maxZoom to 18, the map will no longer zoom in more than the satellite imagery will allow, thereby preventing the confusing switch back to the regular base map. 

Here's a screenshot of what our constrained max zoom looks like. I believe it is zoomed in enough to allow easy clicking on the different point features, even if they are very near each other. 

![image](https://user-images.githubusercontent.com/7842151/39413305-3753f4ae-4bdd-11e8-84a3-3cb5e89e7924.png)
